### PR TITLE
GHC 7.10 compatability, now 0.4.0.2

### DIFF
--- a/Codec/MIME/Parse.hs
+++ b/Codec/MIME/Parse.hs
@@ -107,7 +107,7 @@ normalizeCRLF t
     | T.null t = ""
     | "\r\n" `T.isPrefixOf` t = "\r\n" <> normalizeCRLF (T.drop 2 t)
     | any (`T.isPrefixOf` t) ["\r", "\n"] = "\r\n" <> normalizeCRLF (T.drop 1 t)
-    | otherwise = let (a,b) = T.break (`elem` "\r\n") t in a <> normalizeCRLF b
+    | otherwise = let (a,b) = T.break (`elem` ['\r','\n']) t in a <> normalizeCRLF b
   
 parseMIMEMessage :: T.Text -> MIMEValue
 parseMIMEMessage entity =
@@ -263,7 +263,7 @@ isHSpace :: Char -> Bool
 isHSpace c = c == ' ' || c == '\t'
 
 isTSpecial :: Char -> Bool
-isTSpecial x = x `elem` "()<>@,;:\\\"/[]?=" -- "
+isTSpecial x = x `elem` ("()<>@,;:\\\"/[]?="::String) -- "
 
 dropFoldingWSP :: T.Text -> T.Text
 dropFoldingWSP t | T.null t   = ""

--- a/mime.cabal
+++ b/mime.cabal
@@ -1,5 +1,5 @@
 name:               mime
-version:            0.4.0.1
+version:            0.4.0.2
 synopsis:           Working with MIME types.
 description:        Working with MIME types.
 category:           Codec


### PR DESCRIPTION
Hi There - made two small changes to enable error-free compilation with GHC 7.10 (backwards-compatible). See: https://ghc.haskell.org/trac/ghc/wiki/Migration/7.10
