### PR TITLE
Fix quoted printable

### DIFF
--- a/Codec/MIME/QuotedPrintable.hs
+++ b/Codec/MIME/QuotedPrintable.hs
@@ -25,6 +25,7 @@ import Data.Char
 decode :: String -> String
 decode "" = ""
 decode ('=':'\r':'\n':xs) = decode xs -- soft line break.
+decode ('=':'\n':xs) = decode xs -- soft line break. We don't assume \r\n.
 decode ('=':x1:x2:xs)
  | isHexDigit x1 && isHexDigit x2 =
     chr (digitToInt x1 * 16 + digitToInt x2) : decode xs

--- a/mime.cabal
+++ b/mime.cabal
@@ -8,7 +8,7 @@ license-file:       LICENSE
 author:             Sigbjorn Finne, Galois, Inc.
 maintainer:         Sigbjorn Finne <sigbjorn.finne@gmail.com>
 Copyright:          (c) 2006-2009 Galois Inc.
-cabal-version:      >= 1.6
+cabal-version:       >=1.10
 build-type:         Simple
 homepage:           https://github.com/GaloisInc/mime
 Extra-Source-Files: CHANGES
@@ -24,6 +24,12 @@ library
                    Codec.MIME.Decode
                    Codec.MIME.QuotedPrintable
   ghc-options:     -Wall
+
+test-suite tester
+  type:                exitcode-stdio-1.0
+  hs-source-dirs: test
+  main-is: Main.hs
+  build-depends: base, text, bytestring, mime, hspec
 
 source-repository head
   type:     git

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,1 @@
+resolver: lts-11.13

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- |
+
+module Main where
+
+import qualified Codec.MIME.QuotedPrintable as QP
+import qualified Data.ByteString.Char8 as S8
+import           Data.Text ()
+import qualified Data.Text.Encoding as T
+import           Test.Hspec
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = do
+  describe
+    "QuotedPrintable"
+    (it
+       "Decode regression test"
+       (shouldBe
+          (T.decodeUtf8
+             (S8.pack
+                (QP.decode
+                   "/home/mlitchard/projects/git/reflex-todo/.stack-work/downloaded/Vheiln5kqwE=\n\
+                   \0/src/JSDOM/Custom/XMLHttpRequest.hs:39:46: error:\n\
+                   \    =E2=80=A2 Could not deduce (Control.Monad.Catch.MonadThrow\n\
+                   \                          Language.Javascript.JSaddle.Types.JSM)\n\
+                   \        arising from a use of =E2=80=98throwM=E2=80=99\n\
+                   \      from the context: MonadDOM m\n\
+                   \        bound by the type signature for:\n\
+                   \                   throwXHRError :: MonadDOM m =3D&gt; Maybe XHRError -&gt;=\n\
+                   \ m ()\n\
+                   \        at src/JSDOM/Custom/XMLHttpRequest.hs:38:1-53\n\
+                   \    =E2=80=A2 In the second argument of =E2=80=98(.)=E2=80=99, namely =E2=\n\
+                   \=80=98throwM=E2=80=99\n\
+                   \      In the second argument of =E2=80=98maybe=E2=80=99, namely =E2=80=98(l=\n\
+                   \iftDOM . throwM)=E2=80=99\n\
+                   \      In the expression: maybe (return ()) (liftDOM . throwM)")))
+          "/home/mlitchard/projects/git/reflex-todo/.stack-work/downloaded/Vheiln5kqwE0/src/JSDOM/Custom/XMLHttpRequest.hs:39:46: error:\n\
+          \    • Could not deduce (Control.Monad.Catch.MonadThrow\n\
+          \                          Language.Javascript.JSaddle.Types.JSM)\n\
+          \        arising from a use of ‘throwM’\n\
+          \      from the context: MonadDOM m\n\
+          \        bound by the type signature for:\n\
+          \                   throwXHRError :: MonadDOM m =&gt; Maybe XHRError -&gt; m ()\n\
+          \        at src/JSDOM/Custom/XMLHttpRequest.hs:38:1-53\n\
+          \    • In the second argument of ‘(.)’, namely ‘throwM’\n\
+          \      In the second argument of ‘maybe’, namely ‘(liftDOM . throwM)’\n\
+          \      In the expression: maybe (return ()) (liftDOM . throwM)"))


### PR DESCRIPTION
I have received in the wild a message with `=\n` in it, rather than what this lib expected which was `=\r\n`. 

I fixed it and included a regression test for it with the offending example.

